### PR TITLE
librarian: Gemma 4 inline reasoning-channel parsing (brief 02 completeness)

### DIFF
--- a/TODO_DEFERRED.md
+++ b/TODO_DEFERRED.md
@@ -734,6 +734,26 @@ streaming, or to the prompt?") surfacing in the typed-event parser.
 
 Discovered during the brief-02 ooba cross-backend regression test (2026-06-05).
 
+## Parse Gemma's inline tool-call spelling if a raw-passthrough backend needs it
+
+The `StreamParser` (`raven/librarian/llmclient.py`) parses the generic / Qwen inline tool-call form
+(`<tool_call>{json}</tool_call>`) but not Gemma's: `<|tool_call>call:NAME{...}<tool_call|>` (inner pipes, a
+`call:` prefix, and a non-JSON argument body using Gemma's `<|"|>`-quoted values). On LM Studio — the
+live-verified Gemma 4 backend — tool calls arrive structured in the OpenAI `tool_calls` field, so there is
+nothing to parse inline. The open question is whether a raw-passthrough backend (oobabooga, or a generic
+OpenAI-compat server) serving Gemma emits the tool call inline in `content` instead — exactly the way it does
+for the reasoning channel, which is why we added inline `<|channel>thought` parsing. If one does, Gemma
+tool-calling on that backend would silently break: the call renders as text and never invokes the tool.
+
+Deferred rather than built speculatively, because (a) the need is unverified — we don't yet know that any
+backend we use passes Gemma tool calls inline-raw; and (b) the argument body is not JSON, so a correct parser
+must be written against *real captured output*, not guessed. Resolve by: load Gemma 4 on ooba (currently on
+Qwen3-2507; ooba is also overdue an update), enable tools, and capture the raw streamed `content` of a
+tool-calling turn. If it carries `<|tool_call>call:...` inline, write a parser for that syntax (+ tests)
+anchored on the capture. If ooba delivers the call structured instead, close this item — there is nothing to do.
+
+Discovered during the brief-02 Gemma 4 reasoning-channel work (2026-06-05).
+
 ## DearPyGui_Markdown inline-code background boxes are stranded on dynamic reflow
 
 Inline-code spans (`` `like this` ``) render a grey rounded background box behind the text. The box position is

--- a/TODO_DEFERRED.md
+++ b/TODO_DEFERRED.md
@@ -704,6 +704,36 @@ in hand; this is purely a streaming-renderer presentation change.
 
 Discovered during brief 02 §9 live validation, suggested by Juha (2026-06-04).
 
+## Streaming thinking shows as gray (not blue) for models that pre-fill the opening `<think>` tag
+
+QwQ-32B-style thinking models (and Qwen3-2507 as served by ooba) are trained to *begin thinking immediately*:
+their chat template pre-fills `<think>\n` into the prompt tail, so the generated stream starts already inside
+the think block and emits only the **closing** `</think>`. The `StreamParser` (`llmclient.py`) starts in
+`_PS_TEXT` and only transitions to `_PS_THINK` on seeing an *opening* `<think>` — which never arrives — so the
+entire thinking phase streams as `content` events and renders gray (visible answer), not blue (thought). The
+*completed* message renders correctly: `chatutil.scrub` already recovers the orphan close (detects a `</think>`
+with no matching open and prepends the opening tag — the long-standing QwQ-32B note at `chatutil.py:815-827`),
+so the thinking consolidates into its bubble on finalize. Net effect: thinking is gray while streaming, then
+"snaps" blue/into-a-bubble on completion. Stopping *mid-thinking* leaves it gray (the close never arrived).
+
+**Not a brief-02 regression** — the pre-PR-B `on_llm_progress` had the identical limitation (its
+`inside_think_block` flag also only flipped on a literal `<think>`, so a pre-filled open never registered live);
+confirmed by diffing `09a88a7`. Models that emit the opening tag inline (e.g. ooba's Qwen3-VL-30B) are
+unaffected — they stream blue correctly both before and after PR-B.
+
+The hard part is that the opening tag's *absence is the correct, expected output* for these models, so there is
+no in-stream signal until `</think>` lands — by which point the thinking has already streamed gray. Possible
+fixes, none free: (a) start the parser in `_PS_THINK` when we know the model pre-fills the tag — needs a
+per-model/backend signal we don't currently have at invoke time (the rendered prompt tail would show the open
+`<think>`, but ooba renders server-side; an `/v1/internal/...` prompt-render probe could expose it); (b) on the
+first orphan `</think>`, retroactively re-tint the already-committed streaming paragraphs as thought (recolor +
+flip `is_thought`) — correct but invasive in the streaming renderer. Related to the "bubble from the first
+token" item above, but distinct: there the thinking is *already* detected (blue, just inline); here it is *not
+detected at all* until completion. This is the `chatutil.py:827` TODO ("add the opening `<think>` while
+streaming, or to the prompt?") surfacing in the typed-event parser.
+
+Discovered during the brief-02 ooba cross-backend regression test (2026-06-05).
+
 ## DearPyGui_Markdown inline-code background boxes are stranded on dynamic reflow
 
 Inline-code spans (`` `like this` ``) render a grey rounded background box behind the text. The box position is

--- a/briefs/summer_2026_librarian_extension/gemma4_probe.py
+++ b/briefs/summer_2026_librarian_extension/gemma4_probe.py
@@ -1,0 +1,151 @@
+"""V4 probe: does LM Studio render a Gemma history with reasoning_content + tool_calls?
+
+Mirrors raven's resend payload shape (llmclient.invoke). The decisive question is whether
+LM Studio's minja can render Gemma's chat_template for a tool-call-bearing assistant turn
+(last night it threw "Cannot call something that is not a function: got UndefinedValue").
+
+Run with LM Studio up and a Gemma model loaded. Usage:
+    python /tmp/v4_gemma_probe.py [base_url]
+"""
+import json
+import sys
+
+import requests
+
+BASE = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:1234"
+
+
+def discover_loaded():
+    """Return (model_id, record) for the loaded model via LM Studio's native endpoint."""
+    data = requests.get(f"{BASE}/api/v0/models", timeout=10).json().get("data", [])
+    loaded = [m for m in data if m.get("state") == "loaded"]
+    if not loaded:
+        print(f"No model loaded. Available: {[m.get('id') for m in data]}")
+        sys.exit(1)
+    rec = loaded[0]
+    return rec.get("id"), rec
+
+
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string", "description": "City name"}},
+            "required": ["city"],
+        },
+    },
+}]
+
+# A resend history exactly as raven would rebuild it on a tool-continuation turn:
+# the assistant turn carries BOTH reasoning_content (sibling field) AND structured tool_calls,
+# followed by the tool result. This is the shape that broke minja last night.
+MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant. Use tools when appropriate."},
+    {"role": "user", "content": "What's the weather in Paris right now?"},
+    {"role": "assistant",
+     "content": "",
+     "reasoning_content": "The user is asking for the current weather in Paris. "
+                          "I should call get_weather with city=Paris.",
+     "tool_calls": [{
+         "id": "call_0",
+         "type": "function",
+         "index": "0",
+         "function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})},
+     }]},
+    {"role": "tool",
+     "tool_call_id": "call_0",
+     "content": json.dumps({"temp_c": 14, "conditions": "light rain"})},
+]
+
+
+def main():
+    model_id, rec = discover_loaded()
+    print(f"Loaded model: {model_id}")
+    print(f"  arch={rec.get('arch')} quant={rec.get('quantization')} "
+          f"ctx={rec.get('loaded_context_length')}")
+    print(f"LM Studio: {BASE}\n")
+
+    data = {
+        "stream": True,
+        "model": model_id,
+        "messages": MESSAGES,
+        "tools": TOOLS,
+        "stream_options": {"include_usage": True},
+        "max_tokens": 512,
+    }
+
+    resp = requests.post(f"{BASE}/v1/chat/completions", json=data, stream=True, timeout=120)
+    print(f"HTTP {resp.status_code}\n")
+
+    content_buf = []
+    reasoning_buf = []
+    tool_calls = []
+    error_msg = None
+    finish_reason = None
+    saw_done = False
+
+    for raw in resp.iter_lines():
+        if not raw:
+            continue
+        line = raw.decode("utf-8")
+        if line.startswith("event:"):
+            if "error" in line:
+                error_msg = error_msg or "(event: error)"
+            continue
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if payload == "[DONE]":
+            saw_done = True
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            print(f"  !! non-JSON data line: {payload!r}")
+            continue
+        if "error" in obj:
+            err = obj["error"]
+            error_msg = err.get("message") if isinstance(err, dict) else str(err)
+            continue
+        choices = obj.get("choices") or []
+        if not choices:
+            if obj.get("usage"):
+                print(f"  usage: {obj['usage']}")
+            continue
+        delta = choices[0].get("delta") or {}
+        if delta.get("content"):
+            content_buf.append(delta["content"])
+        if delta.get("reasoning_content"):
+            reasoning_buf.append(delta["reasoning_content"])
+        for tc in delta.get("tool_calls") or []:
+            tool_calls.append(tc)
+        if choices[0].get("finish_reason"):
+            finish_reason = choices[0]["finish_reason"]
+
+    print("=" * 60)
+    if error_msg:
+        print(f"❌ TEMPLATE / RENDER ERROR: {error_msg}")
+        print("   -> minja still cannot render this GGUF's template for a")
+        print("      tool-call + reasoning_content history. Next: override")
+        print("      with Google's official chat_template.jinja.")
+    else:
+        print("✅ RENDERED OK — no minja error on reasoning_content + tool_calls.")
+        print(f"   finish_reason={finish_reason}  [DONE]={saw_done}")
+        if reasoning_buf:
+            print(f"\n   reasoning_content ({len(''.join(reasoning_buf))} chars):")
+            print("   " + "".join(reasoning_buf)[:400].replace("\n", "\n   "))
+        if content_buf:
+            print(f"\n   content ({len(''.join(content_buf))} chars):")
+            print("   " + "".join(content_buf)[:400].replace("\n", "\n   "))
+        if tool_calls:
+            print(f"\n   tool_calls: {json.dumps(tool_calls)[:300]}")
+        if not content_buf and not reasoning_buf and not tool_calls:
+            print("   (empty output — rendered but model produced nothing)")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/raven/librarian/llmclient.py
+++ b/raven/librarian/llmclient.py
@@ -642,12 +642,37 @@ def _materialize_tool_calls(accumulator: Dict[int, Dict[str, str]]) -> Optional[
 # and re-routes them into typed events, so the chat client never has to regex-sniff the text. See brief 02 §9.
 _THINK_OPEN = "<think>"
 _THINK_CLOSE = "</think>"
+
+# The generic / Qwen-style inline tool-call spelling: a JSON object between `<tool_call>` and `</tool_call>`.
+# This is the only inline tool-call form we parse. Gemma's spelling is different — `<|tool_call>call:` NAME
+# `{...}<tool_call|>` (inner pipes, a `call:` prefix, and a bespoke non-JSON argument body) — and we don't parse
+# it. On LM Studio (the live-verified Gemma backend) tool calls arrive structured in the OpenAI `tool_calls`
+# field, so there's nothing to parse inline. Whether a raw-passthrough backend (oobabooga / generic) serving
+# Gemma emits this form inline in `content` instead — the way it does for the reasoning channel below — is
+# unverified; if one does, Gemma tool-calling there would need a dedicated parser for the `call:...` syntax.
 _TOOLCALL_OPEN = "<tool_call>"
 _TOOLCALL_CLOSE = "</tool_call>"
 
+# Gemma 3/4 spell the reasoning channel differently from the `<think>` convention: an asymmetric
+# `<|channel>thought` ... `<channel|>` pair (Gemma emits the channel name `thought` right after the opening
+# marker; see the model's chat template). A backend that passes the raw stream through (oobabooga, generic
+# OpenAI-compat) delivers this inline in `content`; llama.cpp / LM Studio split it out into the native
+# `reasoning_content` delta channel instead (handled directly in `StreamParser.feed`). We match the opening
+# marker without a trailing newline so a stray whitespace variation can't hide it — the model's `\n` after
+# `thought` just rides along into the reasoning text, same as the blank line Qwen emits after `<think>`.
+_GEMMA_THINK_OPEN = "<|channel>thought"
+_GEMMA_THINK_CLOSE = "<channel|>"
+
+# Every reasoning-open tag mapped to the close that ends it. `_PS_TEXT` scans for any open; on a match the
+# parser remembers the corresponding close to scan for while in `_PS_THINK` (the `<think>` and Gemma pairs
+# are not interchangeable — `<think>` closes with `</think>`, `<|channel>thought` closes with `<channel|>`).
+_THINK_OPEN_TO_CLOSE = {_THINK_OPEN: _THINK_CLOSE,
+                        _GEMMA_THINK_OPEN: _GEMMA_THINK_CLOSE}
+_THINK_OPEN_TAGS = tuple(_THINK_OPEN_TO_CLOSE.keys())  # just the opens; `.keys()` spelled out for clarity
+
 # Parser states.
 _PS_TEXT = "text"          # outside any special block
-_PS_THINK = "think"        # inside an inline <think>...</think> block
+_PS_THINK = "think"        # inside an inline reasoning block (<think>...</think> or Gemma's channel form)
 _PS_TOOLCALL = "toolcall"  # inside an inline <tool_call>...</tool_call> block
 
 def _longest_partial_tag_suffix(buf: str, tags: Tuple[str, ...]) -> int:
@@ -709,7 +734,10 @@ class StreamParser:
 
       - routes `reasoning_content` deltas straight to `reasoning` events (the native separate channel that
         llama.cpp / LM Studio use for Qwen / Gemma / GPT-OSS);
-      - parses inline `<think>...</think>` out of the `content` stream into `reasoning` events;
+      - parses inline reasoning out of the `content` stream into `reasoning` events — both the `<think>`
+        convention (Qwen and most others) and Gemma's `<|channel>thought` ... `<channel|>` form, for backends
+        (oobabooga, generic OpenAI-compat) that pass the model's raw stream through instead of splitting the
+        reasoning into the native channel above;
       - parses inline `<tool_call>...</tool_call>` out of the `content` stream into `tool_call` events;
       - emits everything else as `content` events;
 
@@ -729,10 +757,11 @@ class StreamParser:
     """
     def __init__(self):
         self._state = _PS_TEXT
-        self._buf = ""                  # content look-ahead buffer (may hold a split tag at a chunk boundary)
-        self._toolcall_json = ""        # accumulates the raw JSON inside an inline <tool_call> block
-        self._inline_call_keys = set()  # (name, normalized args) of inline-emitted calls, for native dedup
-        self._synthetic_id_counter = 0  # inline tool calls carry no id; assign a synthetic one
+        self._buf = ""                   # content look-ahead buffer (may hold a split tag at a chunk boundary)
+        self._think_close = _THINK_CLOSE  # the close tag that ends the current _PS_THINK block (set on open)
+        self._toolcall_json = ""         # accumulates the raw JSON inside an inline <tool_call> block
+        self._inline_call_keys = set()   # (name, normalized args) of inline-emitted calls, for native dedup
+        self._synthetic_id_counter = 0   # inline tool calls carry no id; assign a synthetic one
 
     def feed(self, content: str, reasoning: str) -> List[Dict]:
         """Feed one delta's content and reasoning_content (either may be empty). Returns the typed events produced."""
@@ -750,23 +779,24 @@ class StreamParser:
         while progressing and self._buf:
             progressing = False
             if self._state == _PS_TEXT:
-                emit, tag, rest = _scan_for_tags(self._buf, (_THINK_OPEN, _TOOLCALL_OPEN))
+                emit, tag, rest = _scan_for_tags(self._buf, _THINK_OPEN_TAGS + (_TOOLCALL_OPEN,))
                 if emit:
                     events.append({"type": "content", "text": emit})
                 self._buf = rest
-                if tag == _THINK_OPEN:
+                if tag in _THINK_OPEN_TO_CLOSE:
                     self._state = _PS_THINK
+                    self._think_close = _THINK_OPEN_TO_CLOSE[tag]  # the matching close (<think> and Gemma differ)
                     progressing = True
                 elif tag == _TOOLCALL_OPEN:
                     self._state = _PS_TOOLCALL
                     self._toolcall_json = ""
                     progressing = True
             elif self._state == _PS_THINK:
-                emit, tag, rest = _scan_for_tags(self._buf, (_THINK_CLOSE,))
+                emit, tag, rest = _scan_for_tags(self._buf, (self._think_close,))
                 if emit:
                     events.append({"type": "reasoning", "text": emit})
                 self._buf = rest
-                if tag == _THINK_CLOSE:
+                if tag == self._think_close:
                     self._state = _PS_TEXT
                     progressing = True
             else:  # _PS_TOOLCALL: accumulate raw JSON until the closing tag

--- a/raven/librarian/tests/test_llmclient.py
+++ b/raven/librarian/tests/test_llmclient.py
@@ -535,6 +535,27 @@ class TestStreamParser:
         assert "<think>" not in self._texts(events, "content")
         assert "think" not in self._texts(events, "content")
 
+    def test_inline_gemma_channel_extracted_from_content(self):
+        # Gemma 3/4 spell the reasoning channel as `<|channel>thought ... <channel|>`. A passthrough backend
+        # (ooba/generic) delivers it inline; the parser must route it to reasoning, same as `<think>`.
+        events = self._run([("<|channel>thought\nThe user wants Paris weather.\n<channel|>The answer.", "")])
+        assert self._texts(events, "reasoning").strip() == "The user wants Paris weather."
+        assert self._texts(events, "content") == "The answer."
+        assert "channel" not in self._texts(events, "content")  # no marker text leaks
+
+    def test_inline_gemma_channel_split_across_chunks(self):
+        # Both the asymmetric open (`<|channel>thought`) and close (`<channel|>`) markers may straddle a chunk
+        # boundary; the look-ahead must still recognize them without leaking marker text to content.
+        events = self._run([("<|chan", ""), ("nel>thoughtsecret th", ""), ("oughts<chan", ""), ("nel|>visible", "")])
+        assert self._texts(events, "reasoning") == "secret thoughts"
+        assert self._texts(events, "content") == "visible"
+        assert "channel" not in self._texts(events, "content")
+
+    def test_inline_gemma_unterminated_channel_flushed_at_finalize(self):
+        # Stream cut off mid-thought (interrupt): the buffered Gemma reasoning flushes, not lost.
+        events = self._run([("<|channel>thought\ncut off mid-thou", "")])
+        assert self._texts(events, "reasoning").strip() == "cut off mid-thou"
+
     def test_less_than_that_is_not_a_tag_passes_through(self):
         # A bare '<' (e.g. an inequality) is not a tag prefix worth holding forever; it streams as content.
         events = self._run([("if a < b then", "")])


### PR DESCRIPTION
Completes Gemma 4 reasoning support in the typed-event stream parser (brief 02 §9 follow-up).

## What

The `StreamParser` recognized only the `<think>...</think>` reasoning convention. Gemma 3/4 spell their reasoning channel differently — `<|channel>thought ... <channel|>` — so on a raw-passthrough backend (oobabooga, generic OpenAI-compat) Gemma's thinking streamed in as plain `content` and never showed as a thought bubble. (LM Studio / llama.cpp split it into the native `reasoning_content` channel, already handled.) The parser now recognizes the Gemma open/close pair too, fulfilling the already-shipped contract that the thinking trace shows *regardless of how the backend delivers it*.

## V4 verification (Gemma reasoning round-trip)

Confirmed at the prompt level by rendering the official / lmstudio-community Gemma 4 chat template in Python Jinja2 with a `reasoning_content`-bearing tool-call history: the template re-emits the stored reasoning as `<|channel>thought\n…\n<channel|>` in the intra-turn tool-call-continuation case. So PR-B's sibling-field design round-trips correctly through Gemma's template. The inline marker spelling in this PR is anchored on that real rendered output.

## Scope / deferred

- Gemma's **bespoke inline tool-call** spelling (`<|tool_call>call:NAME{…}<tool_call|>`, non-JSON args) is **not** parsed — tool calls arrive structured on LM Studio; whether a raw-passthrough backend emits them inline is unverified. Deferred with a resolution recipe (capture real ooba+Gemma output first) in `TODO_DEFERRED.md`.
- A separate `TODO_DEFERRED.md` note records the pre-existing gray-streaming limitation for models that pre-fill the opening `<think>` (Qwen3-2507 / QwQ-32B) — found during the ooba cross-backend regression test, not a regression.

## Tests

3 new `StreamParser` tests (basic Gemma channel, split-across-chunks, unterminated-at-EOS). Full librarian suite green (310 passed), ruff clean.

## Not yet live-validated

The inline path needs a backend that serves Gemma with raw passthrough; ooba is on Qwen3-2507 and not being updated today, so the inline path is covered by unit tests against the verified spelling. LM Studio (lmstudio-community GGUF) exercises the *native* `reasoning_content` channel, not this inline path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)