### PR TITLE
ci: pin GitHub Actions to commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -56,9 +56,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,9 +9,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -32,6 +32,6 @@ jobs:
         run: pytest raven/ -v --tb=short -m "not ml" --cov=raven --cov-branch --cov-report=xml:coverage.xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Supply-chain hardening, fan-out from the wlsqm pilot.

Pins every `uses:` to an immutable commit SHA (+ `# vX.Y.Z` comment) instead of a floating tag/branch. A floating ref can be silently repointed if an action repo or maintainer account is compromised (cf. `tj-actions/changed-files`, March 2025); a SHA cannot. SHAs target the latest release of each action — all reviewed this session (codecov v7.0.0 GPG-signed with maintainer-key continuity; cibuildwheel v4.0.0 PyPA/henryiii). Dependabot understands SHA-pinned actions and bumps both the SHA and the comment, so updates still flow as reviewable PRs.

Pure hardening — pinned commits are the current latest releases, so CI runs the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)